### PR TITLE
add moment dependency in Home bundle

### DIFF
--- a/examples/code-splitting/src/routes/home/HomeComponent.ts
+++ b/examples/code-splitting/src/routes/home/HomeComponent.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import * as moment from 'moment';
 
 export class HomeComponent {
     public name: string;

--- a/examples/code-splitting/src/routes/home/HomeComponent.ts
+++ b/examples/code-splitting/src/routes/home/HomeComponent.ts
@@ -1,6 +1,8 @@
+import moment from 'moment';
+
 export class HomeComponent {
     public name: string;
     constructor() {
-        this.name = "Hello, i am home"
+        this.name = `Hello, i am home at ${moment().format('YYYY MM DD')}`
     }
 }


### PR DESCRIPTION
This PR demonstrates an issue when an imported bundle has a dependency such as `moment`:

```
Uncaught (in promise) Package not found moment
```

